### PR TITLE
Fix urllib3 version

### DIFF
--- a/scripts/ansible/deploy-to-vm.yml
+++ b/scripts/ansible/deploy-to-vm.yml
@@ -57,6 +57,7 @@
         name:
           - docker==6.1.3
           - docker-compose==1.29.2
+          - urllib3==1.26.18
 
     - name: Make sure deploy user belong to group and "docker" group
       user:


### PR DESCRIPTION
urllib3 v2.0+ dropped support OpenSSL older than 1.1.1. However, this OpenSSL is still available on most of Amazon Linux image. This PR to set the latest stable v1 version of urllib3 to make the deployment script backwards compatible